### PR TITLE
Refactor to use context and error channel

### DIFF
--- a/async.go
+++ b/async.go
@@ -7,7 +7,7 @@ import (
 // Task is a function that can be run concurrently.
 type Task func() error
 
-// Run will execute the given tasks concurrently and stop if a task returns an error.
+// Run will execute the given tasks concurrently and return any errors.
 func Run(tasks ...Task) <-chan error {
 	errc := make(chan error)
 

--- a/async.go
+++ b/async.go
@@ -75,3 +75,14 @@ func RunLimited(concurrent int, count int, task Task) error {
 
 	return nil
 }
+
+// Wait until channel is closed or error is received.
+func Wait(errc <-chan error) error {
+	for err := range errc {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/async_test.go
+++ b/async_test.go
@@ -93,6 +93,31 @@ func Test_RunLimited_Success(t *testing.T) {
 	assert.Equal(t, int32(12), count)
 }
 
+func Test_RunLimited_Cancel(t *testing.T) {
+	// arrange
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var count int32
+	task := func() error {
+		atomic.AddInt32(&count, 1)
+
+		if count >= 6 {
+			cancel()
+		}
+
+		return nil
+	}
+
+	// act
+	errc := RunLimited(ctx, 3, 4, task)
+	err := Wait(errc)
+
+	// assert
+	assert.Error(t, err)
+	assert.True(t, count >= 6)
+	assert.True(t, count < 12)
+}
+
 func Test_RunLimited_Error(t *testing.T) {
 	// arrange
 	ctx := context.Background()

--- a/async_test.go
+++ b/async_test.go
@@ -122,13 +122,13 @@ func Test_RunForever_Cancel(t *testing.T) {
 	// arrange
 	ctx, cancel := context.WithCancel(context.Background())
 
-	count := 0
+	var count int32
 	task := func() error {
+		atomic.AddInt32(&count, 1)
+
 		if count >= 10 {
 			cancel()
 		}
-
-		count++
 
 		return nil
 	}
@@ -180,13 +180,13 @@ func Test_RunForever_Error(t *testing.T) {
 	// arrange
 	ctx := context.Background()
 
-	count := 0
+	var count int32
 	task := func() error {
+		atomic.AddInt32(&count, 1)
+
 		if count >= 10 {
 			return errors.New("task error")
 		}
-
-		count++
 
 		return nil
 	}

--- a/async_test.go
+++ b/async_test.go
@@ -8,7 +8,7 @@ import (
 	assert "github.com/stretchr/testify/require"
 )
 
-func Test_Run_Successful(t *testing.T) {
+func Test_Run_Success(t *testing.T) {
 	// arrange
 	count1 := 0
 	task1 := func() error {
@@ -66,7 +66,7 @@ func Test_Run_Error(t *testing.T) {
 	assert.Equal(t, 1, count3)
 }
 
-func Test_RunLimited_Successful(t *testing.T) {
+func Test_RunLimited_Success(t *testing.T) {
 	// arrange
 	count := 0
 	task := func() error {
@@ -104,7 +104,7 @@ func Test_RunLimited_Error(t *testing.T) {
 	assert.Equal(t, 8, count)
 }
 
-func Test_RunForever_Successful(t *testing.T) {
+func Test_RunForever_Success(t *testing.T) {
 	// arrange
 	var wg sync.WaitGroup
 	wg.Add(12)


### PR DESCRIPTION
- Change methods to return an error channel, so all errors can be retrieved.
- Change looping methods to use a context for cancellation, to prevent additional tasks from being run.
- Add Wait method to wait for an error to occur or all tasks to complete.
- Update tests to fix race conditions.