### PR TITLE
Add method for handling errors from an error channel

### DIFF
--- a/async.go
+++ b/async.go
@@ -114,3 +114,14 @@ func Wait(errc <-chan error) error {
 
 	return nil
 }
+
+// HandleError sets a handler function to be called anytime an error is received on the given channel.
+func HandleError(errc <-chan error, handler func(error)) {
+	go func() {
+		for err := range errc {
+			if err != nil {
+				handler(err)
+			}
+		}
+	}()
+}


### PR DESCRIPTION
- Method to assign a handler to an error channel that will get called anytime an error is received.